### PR TITLE
Related content fix

### DIFF
--- a/content/historical/panic.md
+++ b/content/historical/panic.md
@@ -4,37 +4,37 @@ image_file: site/i18146thmb.jpg
 image_caption: "Interior of Board of Trade, the pit"
 related_content:
   - title: "1890 Census: Report On Vital & Social Statistics in the U.S"
-    url:
+    url: fk_03194297.pdf
   - title: "A History of Chicago (Vol. 3: The Rise of a Modern City, 1871-1893)"
-    url:
+    url: fk_04755641_03.pdf
   - title: "Annual Report of the Factory Inspectors of Illinois on Small Pox in the Tenement House Sweat-Shops of Chicago (First Special Report)"
-    url:
+    url: fk_12739373.pdf
   - title: "Biennial Report of the Department of Health of the City of Chicago 1895-96"
-    url:
+    url: fk_04420608.pdf
   - title: "Centennial History of Illinois: vol. 5 (The Modern Commonwealth, 1893-1918)"
-    url:
+    url: fk_00771461.pdf
   - title: "Factory Inspection in the United States"
-    url:
+    url: fk_2762420.pdf
   - title: "Henry Demarest Lloyd, 1847-1903, A Biography Vol. 1"
-    url:
+    url: fk_01549264_01.pdf
   - title: "Henry Demarest Lloyd, 1847-1903, A Biography Vol. 2"
-    url:
+    url: fk_01549264_02.pdf
   - title: "If Christ Came to Chicago"
     url: fk_02010144.pdf
   - title: "Report of the Illinois Bureau of Labor Statistics - 1890 - 6th Biennial"
-    url:
+    url: fk_02195483-06.pdf
   - title: "Report of the Illinois Bureau of Labor Statistics - 1892 - 7th Biennial"
-    url:
+    url: fk_2195483-07.pdf
   - title: "Report of the Illinois Bureau of Labor Statistics - 1894 - 8th Biennial"
-    url:
+    url: fk_2195483-08.pdf
   - title: "Report of the Illinois Bureau of Labor Statistics - 1896 - 9th Biennial"
-    url:
+    url: fk_2195483-09.pdf
   - title: "Report of the Illinois Bureau of Labor Statistics - 1898 - 10th Biennial"
-    url:
+    url: fk_2195483-10.pdf
   - title: "Slums of the Great Cities - Baltimore, Chicago, Philadelphia & New York"
-    url:
+    url: fk_34440001.pdf
   - title: "The Chicago Strike"
-    url:
+    url: fk_02485689.pdf
 ---
 
 [The Panic of 1893](https://en.wikipedia.org/wiki/Panic_of_1893) was a true and severe financial panic lasting from May of 1893 to November, 1893, with a run on currency, and banks closing, and businesses and manufacturers not being able to open because they had not cash to pay workers or buy materials. The panic included precipitous declines in the stock market, the failure of Wall Street brokerage houses, and the failure of 158 national banks in 1893, mostly in the South and West. Other bank failures included 172 state banks, and 177 private banks, as well as 47 savings banks and 13 loan and trust companies and 16 mortgage companies. The panic started in New York and spread to the rest of the country. This was the atmosphere in which Florence Kelley and her colleagues began their work chronicling the economic conditions in the tenements and [slums of Chicago](/fk_documents/fk_34440001.pdf).

--- a/content/historical/stockyards.md
+++ b/content/historical/stockyards.md
@@ -4,15 +4,15 @@ image_file: site/i15014thmb.jpg
 image_caption: "Big sewer entering Bubble Creek Branch."
 related_content:
   - title: "1890 Census: Report On Vital & Social Statistics in the U.S"
-    url:
+    url: fk_03194297.pdf
   - title: "A History of Chicago (Vol. 3: The Rise of a Modern City, 1871-1893)"
-    url:
+    url: fk_04755641_03.pdf
   - title: "If Christ Came to Chicago"
     url: fk_02010144.pdf
   - title: "Moran's Dictionary of Chicago and Its Vicinity"
-    url:
+    url: fk_01884559.pdf
   - title: "The Workers: an Experiment in Reality: The West"
-    url:
+    url: fk_00700194.pdf
 ---
 
 Chronicled in historical accounts, photographs, novels, and newspapers, the stockyards were the icon and essence of 1890’s Chicago – Hog butcher for the world The hub of the new transnational railroad system, the stockyards were where animals – cattle, sheep, pigs – were brought to wait to be slaughtered in of the great [meat processing plants](http://www.encyclopedia.chicagohistory.org/pages/804.html), named after the families whose fortunes they made. The stockyards became themselves the symbol of the engine of economic growth and its excesses.
@@ -25,3 +25,22 @@ For generations of workers and owners -- and the thousands of people providing g
 
 
 Next:  [Lives of Children](/historical/children)
+
+{{< gallery >}}
+  {{< figure link="/img/galleries/historical/i15014.jpg" caption="Big sewer entering Bubble Creek Branch. Description: Big sewer entering Bubble Creek Branch; Chicago, IL. ICHi-15014. Chicago History Museum. Reproduction of photograph; photographer unknown. From Chicago Commons collections. Date: 1905." >}}
+  {{< figure link="/img/galleries/historical/DN-0000936.jpg" caption="Crowd, including women and children, gathered along a road with police and horse-drawn carriages during the 1904 Stockyards Strike. Image of a crowd, including women and children, gathered along a road with police and horse-drawn carriages during the 1904 Stockyards Strike in the New City community area of Chicago, Illinois. Source: DN-0000936, Chicago Daily News negatives collection, Chicago History Museum. Date: ca. 1904 July 7-Sept. 9." >}}
+  {{< figure link="/img/galleries/historical/i52240.jpg" caption="Engraving Stockyards 1868 from Harper's Weekly. Description: Engraving Stockyards 1868 from Harper's Weekly; Chicago, IL. Source: ICHi-52240. Chicago History Museum. Reproduction of photographic print, photographer unknown. Date: October 31, 1868." >}}
+  {{< figure link="/img/galleries/historical/i29983.jpg" caption="Entrance to stockyards. Description: Entrance to stockyards; Chicago, IL. Source: ICHi-29983. Chicago History Museum. Reproduction of photograph, photographer unknown. Date: 1928." >}}
+  {{< figure link="/img/galleries/historical/i32961.jpg" caption="Exchange Street, 200 feet west of the main entrance to the Union Stockyards. Description: Exchange Street, 200 feet west of the main entrance to the Union Stockyards; Chicago IL. Source: ICHi-32961. Chicago History Museum. Reproduction of photographic print, photographer unknown. Chicago History Museum. Date: 1893." >}}
+  {{< figure link="/img/galleries/historical/i52112.jpg" caption="J Ogden Armour Strikes, "We Don't have to pay higher wages we can get the labor we want." Description: "We Don't have to pay higher wages we can get the labor we want" J Ogden ? Armour Strikes; Chicago, IL. Source: ICHi-52112. Chicago History Museum. Reproduction of photographic print, photographer unknown. Date: 1890-1899." >}}
+  {{< figure link="/img/galleries/historical/i15113.jpg" caption="Just coming from the stockyards, lunchroom in stockyards district. Description: Just coming from the stockyards, lunchroom in stockyards district; Chicago, IL. Source: ICH-i15113. Reproduction of photograph, photographer unknown. Date: 1900." >}}
+  {{< figure link="/img/galleries/historical/DN-0000163.jpg" caption="Railroad yard at the rear of the Union Stock Yards. View of a railroad yard at the rear of the Union Stock Yards in Chicago, Illinois, showing various large storage buildings, railroad tracks and piles of lumber and building materials. An Armour and Company building, a Swift and Company building, a bridge and smoke billowing from smokestacks are visible in the background. Source: DN-0000163, Chicago Daily News negatives collection, Chicago History Museum. Date: ca. 1902." >}}
+  {{< figure link="/img/galleries/historical/i16072.jpg" caption="The Pork Packers Plant strike in Chicago. Description: The Pork Packers Plant strike at Chicago, IL. Source: ICHi-16072. Chicago History Museum. Reproduction of engraving, engraver unknown. Date: November 20, 1886." >}}
+  {{< figure link="/img/galleries/historical/DN-0050344.jpg" caption="Unidentified group of men walking away from the Union Stock Yards Gate. Image of an unidentified group of men walking away from the Union Stock Yards Gate at 850 West Exchange Avenue in the New City community area of Chicago, Illinois. The gate was built in 1879. Source: DN-0050344, Chicago Daily News negatives collection, Chicago History Museum. Date: ca. 1906." >}}
+  {{< figure link="/img/galleries/historical/i52216.jpg" caption="Union stockyards from "Views of Chicago and Vicinity." pic 1 Description: Union stockyards from "Views of Chicago and Vicinity;" Chicago, IL. Source: ICHi-52216. Reproduction of photomechanical print, printer unknown. Date: 1890-1899." >}}
+  {{< figure link="/img/galleries/historical/i52217.jpg" caption="Union stockyards from "Views of Chicago and Vicinity." pic 2 Description: Union stockyards from "Views of Chicago and Vicinity;" Chicago, IL. Source: ICHi-52217. Chicago History Museum. Reproduction of photomechanical print, printer unknown. Date: 1890-1899." >}}
+  {{< figure link="/img/galleries/historical/i29982.jpg" caption="Union Stockyards gate with men standing to side. Description: Union Stockyards gate with men standing to side; Chicago, IL. Source: ICHi-29982. Reproduction of photograph, photographer unknown. Date: ca. 1885." >}}
+  {{< figure link="/img/galleries/historical/i13188aa.jpg" caption="Whiskey Row, near Union Stockyards. Description: Whiskey Row, near Union Stockyards; Chicago, IL. Source: ICHi-13188. Chicago History Museum. Reproduction of postcard, printer - V O Hammon Publishing Company. Date: n.d." >}}
+  {{< figure link="/img/galleries/historical/i20069.jpg" caption="Workers at Horn Brothers Furniture Company, before the strike. Description: Workers at Horn Brothers Furniture Company, before the strike. Source: ICHi-20069. Chicago History Museum. Reproduction of photograph, photographer unknown. Date: April 30, 1886." >}}
+  {{< figure link="/img/galleries/historical/i21839.jpg" caption="Canning room, stockyards. Description: Canning room, stockyards; Chicago, IL. Source: ICHi-21839. Chicago History Museum. Reproduction of photograph, creator - J. W. Taylor. Date: 1890's." >}}
+{{< /gallery >}}{{< load-photoswipe >}}

--- a/content/historical/timeline.md
+++ b/content/historical/timeline.md
@@ -4,45 +4,45 @@ image_file: site/i19989thmb.jpg
 image_caption: "8 hour strike Chicago Typographical Union #16."
 related_content:
   - title: "A History of Chicago (Vol. 3: The Rise of a Modern City, 1871-1893)"
-    url:
+    url: fk_04755641_03.pdf
   - title: "A History of the City of Chicago Its Men and Institutions: Biographical Sketches of Leading Citizens"
-    url:
+    url: fk_02023466.pdf
   - title: "Annual Report of the Department of Health of the City of Chicago 1893"
-    url:
+    url: fk_04418389_1.pdf
   - title: "Annual Report of the Department of Health of the City of Chicago 1894"
-    url:
+    url: fk_04418389_2.pdf
   - title: "Annual Report of the Factory Inspectors of Illinois, 1899"
-    url:
+    url: fk_12995219_07.pdf
   - title: "As Others See Chicago: Impressions of Visitors, 1673-1933"
-    url:
+    url: fk_01870344.pdf
   - title: "Biennial Report of the Department of Health of the City of Chicago 1895-96"
-    url:
+    url: fk_04420608.pdf
   - title: "Centennial History of Illinois: vol. 5 (The Modern Commonwealth, 1893-1918)"
-    url:
+    url: fk_00771461.pdf
   - title: "Centennial History of the City of Chicago: Its Men and Institutions"
-    url:
+    url: fk_02032274.pdf
   - title: "Chicago and the American Literary Imagination, 1880-1920"
-    url:
+    url: fk_00908681.pdf
   - title: "Flaws in the Law: Supreme Court Punctures the Eight-Hour Act"
-    url:
+    url: fk_31120016.pdf
   - title: "If Christ Came to Chicago"
     url: fk_02010144.pdf
   - title: "Moran's Dictionary of Chicago and Its Vicinity"
-    url:
+    url: fk_01884559.pdf
   - title: "Politics and Politicians of Chicago, Cook County, and Illinois 1787-1887"
-    url:
+    url: fk_02006243.pdf
   - title: "The Chicago Strike"
-    url:
+    url: fk_02485689.pdf
   - title: "The Pullman Strike : the Story of a Unique Experiment and of a Great Labor Upheaval"
-    url:
+    url: fk_00232352.pdf
   - title: "The Tenements of Chicago, 1908-1935"
-    url:
+    url: fk_03009084.pdf
   - title: "Truancy and Non-Attendance in the Chicago Schools: A Study of the Social Aspects of the Compulsory"
-    url:
+    url: fk_00237739.pdf
   - title: "Education and Child Labor Legislation of Illinois"
-    url:
+    url: fk_1009969.pdf
   - title: "Vice in Chicago"
-    url:
+    url: fk_00238294.pdf
 ---
 Date | Description
 :---: | :---


### PR DESCRIPTION
added url info to the pages timeline, stockyards, and panic. added gallery to stockyards. fixes #16, #17, and #18 